### PR TITLE
Rename directories according to literature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Datasets of votes that can be used with Majority Judgment.
 
 
-## Directory `tallies`
+## Directory `profiles`
 
 Holds CSV (or other formats?) files with the amounts of judgments per grade and per proposal:
 
@@ -17,7 +17,7 @@ Pasta,      4,    5,    1,    4,         0,        2
 The first line defining the grades is optional, and grades MUST be ordered from "worst" to "best".
 
 
-## Directory `judgments`
+## Directory `ballots`
 
 Holds CSV (or other formats?) files with the judgments per proposal of each judge:
 


### PR DESCRIPTION
This PR proposes to rename the directory `tallies` into `profiles`.

Justification: it seems that the scientific literature uses “merit profile” to describe those sums of ballots, as in the recent [Majority judgment vs. majority rule](https://link.springer.com/article/10.1007/s00355-019-01200-x) by Michel Balinski & Rida Laraki.

I also propose to rename `judgments` into `ballots`, to insist on the fact that what we want is the exhaustive list of all cast ballots.

Of course, it is very possible that those proposed names are no improvement, and of course the choice of those names is of little importance…